### PR TITLE
將快門時間顯示為倒數

### DIFF
--- a/photoIso.rb
+++ b/photoIso.rb
@@ -211,7 +211,7 @@ class PhotoIso
 					s += "海拔#{a.gps_altitude.to_f.round(3)}公尺\n" unless a.gps_altitude.nil?
 				end
 				if @setting.exposure_time == "true"
-					s += "快門時間：#{a.exif.exposure_time.to_f.round(4)}\n" unless a.exif.exposure_time.nil?
+					s += "快門時間：1/#{(1 / a.exif.exposure_time.to_f).round}\n" unless a.exif.exposure_time.nil?
 				end
 				if @setting.size == "true"
 					s += "照片大小：#{a.width} * #{a.height}\n" unless a.width.nil? or a.height.nil?


### PR DESCRIPTION
其實應該區分長快門（> 1s）的，不過隨手就(・ω・)
